### PR TITLE
Add a keybind to toggle voidwalker's sash

### DIFF
--- a/src/main/java/taintedmagic/client/ClientProxy.java
+++ b/src/main/java/taintedmagic/client/ClientProxy.java
@@ -13,6 +13,8 @@ import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 import taintedmagic.client.handler.ClientHandler;
 import taintedmagic.client.handler.HUDHandler;
+import taintedmagic.client.handler.SashClientHandler;
+import taintedmagic.client.handler.SashKeyListener;
 import taintedmagic.client.renderer.RenderEntityDiffusion;
 import taintedmagic.client.renderer.RenderEntityHomingShard;
 import taintedmagic.client.renderer.RenderItemKatana;
@@ -49,6 +51,7 @@ public class ClientProxy extends CommonProxy {
 
         FMLCommonHandler.instance().bus().register(new ClientHandler());
         MinecraftForge.EVENT_BUS.register(new ClientHandler());
+        MinecraftForge.EVENT_BUS.register(new SashKeyListener());
     }
 
     @Override
@@ -65,6 +68,11 @@ public class ClientProxy extends CommonProxy {
     @Override
     public EntityPlayer getClientPlayer () {
         return Minecraft.getMinecraft().thePlayer;
+    }
+
+    @Override
+    public boolean isSashEnabled(EntityPlayer player) {
+        return SashClientHandler.isEnabled();
     }
 
     @Override

--- a/src/main/java/taintedmagic/client/handler/SashClientHandler.java
+++ b/src/main/java/taintedmagic/client/handler/SashClientHandler.java
@@ -1,0 +1,24 @@
+package taintedmagic.client.handler;
+
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
+
+public class SashClientHandler {
+
+    private static boolean stashEnabled = true;
+
+    public static void toggle() {
+       stashEnabled = !stashEnabled;
+        if (stashEnabled) {
+            HUDHandler.displayString(EnumChatFormatting.GREEN + StatCollector.translateToLocal("text.sash.speed.on"),
+                    300, false);
+        } else {
+            HUDHandler.displayString(EnumChatFormatting.RED + StatCollector.translateToLocal("text.sash.speed.off"),
+                    300, false);
+        }
+    }
+
+    public static boolean isEnabled() {
+        return stashEnabled;
+    }
+}

--- a/src/main/java/taintedmagic/client/handler/SashClientHandler.java
+++ b/src/main/java/taintedmagic/client/handler/SashClientHandler.java
@@ -5,11 +5,11 @@ import net.minecraft.util.StatCollector;
 
 public class SashClientHandler {
 
-    private static boolean stashEnabled = true;
+    private static boolean sashEnabled = true;
 
     public static void toggle() {
-       stashEnabled = !stashEnabled;
-        if (stashEnabled) {
+       sashEnabled = !sashEnabled;
+        if (sashEnabled) {
             HUDHandler.displayString(EnumChatFormatting.GREEN + StatCollector.translateToLocal("text.sash.speed.on"),
                     300, false);
         } else {
@@ -19,6 +19,6 @@ public class SashClientHandler {
     }
 
     public static boolean isEnabled() {
-        return stashEnabled;
+        return sashEnabled;
     }
 }

--- a/src/main/java/taintedmagic/client/handler/SashKeyListener.java
+++ b/src/main/java/taintedmagic/client/handler/SashKeyListener.java
@@ -1,0 +1,41 @@
+package taintedmagic.client.handler;
+
+import baubles.common.lib.PlayerHandler;
+import cpw.mods.fml.client.registry.ClientRegistry;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.InputEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.item.ItemStack;
+import org.lwjgl.input.Keyboard;
+import taintedmagic.common.items.equipment.ItemVoidwalkerSash;
+import taintedmagic.common.network.PacketHandler;
+import taintedmagic.common.network.PacketSashToggle;
+
+@SideOnly(Side.CLIENT)
+public class SashKeyListener {
+
+    private static final KeyBinding toggleSash = new KeyBinding("tmisc.toggleSash", Keyboard.CHAR_NONE, "tmisc.keyCategory");
+
+    public SashKeyListener() {
+        FMLCommonHandler.instance().bus().register(this);
+        ClientRegistry.registerKeyBinding(toggleSash);
+    }
+
+    @SubscribeEvent
+    public void keyUp(InputEvent.KeyInputEvent event) {
+        if (toggleSash.isPressed()) {
+
+            final ItemStack sash = PlayerHandler.getPlayerBaubles(Minecraft.getMinecraft().thePlayer).getStackInSlot(3);
+            if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash) {
+
+                SashClientHandler.toggle();
+                PacketHandler.INSTANCE.sendToServer(new PacketSashToggle());
+
+            }
+        }
+    }
+}

--- a/src/main/java/taintedmagic/client/handler/SashServerHandler.java
+++ b/src/main/java/taintedmagic/client/handler/SashServerHandler.java
@@ -1,0 +1,29 @@
+package taintedmagic.client.handler;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import taintedmagic.common.TaintedMagic;
+
+public final class SashServerHandler {
+
+    private static final String COMPOUND = TaintedMagic.MOD_ID;
+    private static final String TAG_MODE = "sash_mode";
+
+    private static NBTTagCompound getCompound(EntityPlayer player) {
+        NBTTagCompound cmp = player.getEntityData();
+        if (!cmp.hasKey(COMPOUND))
+            cmp.setTag(COMPOUND, new NBTTagCompound());
+
+        return cmp.getCompoundTag(COMPOUND);
+    }
+
+    public static boolean isSashEnabled(EntityPlayer player) {
+        NBTTagCompound cmp = getCompound(player);
+        return !cmp.hasKey(TAG_MODE) || cmp.getBoolean(TAG_MODE);
+    }
+
+    public static void toggleSashStatus(EntityPlayer player) {
+        NBTTagCompound cmp = getCompound(player);
+        cmp.setBoolean(TAG_MODE, !cmp.getBoolean(TAG_MODE));
+    }
+}

--- a/src/main/java/taintedmagic/common/CommonProxy.java
+++ b/src/main/java/taintedmagic/common/CommonProxy.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
+import taintedmagic.client.handler.SashServerHandler;
 import taintedmagic.common.handler.ConfigHandler;
 import taintedmagic.common.handler.TMEventHandler;
 import taintedmagic.common.handler.UpdateHandler;
@@ -58,6 +59,10 @@ public class CommonProxy {
 
     public EntityPlayer getClientPlayer () {
         return null;
+    }
+
+    public boolean isSashEnabled(EntityPlayer player) {
+        return SashServerHandler.isSashEnabled(player);
     }
 
     public World getClientWorld () {

--- a/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerBoots.java
+++ b/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerBoots.java
@@ -139,7 +139,7 @@ public class ItemVoidwalkerBoots extends ItemArmor
             if (player.onGround || player.capabilities.isFlying) {
                 float bonus = 0.12F;
                 final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
-                if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash && ItemVoidwalkerSash.isSpeedEnabled(sash)) {
+                if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash && TaintedMagic.proxy.isSashEnabled(player)) {
                     bonus *= 2.0F;
                 }
 
@@ -168,7 +168,7 @@ public class ItemVoidwalkerBoots extends ItemArmor
             if (boots != null && boots.getItem() == ItemRegistry.ItemVoidwalkerBoots) {
                 player.motionY *= 1.25D;
             }
-            if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash && ItemVoidwalkerSash.isSpeedEnabled(sash)) {
+            if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash && TaintedMagic.proxy.isSashEnabled(player)) {
                 player.motionY *= 1.05D;
             }
         }

--- a/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerSash.java
+++ b/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerSash.java
@@ -9,12 +9,12 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
-import taintedmagic.client.handler.HUDHandler;
+import taintedmagic.client.handler.SashClientHandler;
+import taintedmagic.client.handler.SashServerHandler;
 import taintedmagic.common.TaintedMagic;
 import thaumcraft.api.IRunicArmor;
 import thaumcraft.api.IWarpingGear;
@@ -22,8 +22,6 @@ import thaumcraft.api.ItemRunic;
 import thaumcraft.common.Thaumcraft;
 
 public class ItemVoidwalkerSash extends ItemRunic implements IRunicArmor, IWarpingGear, IBauble {
-
-    public static final String TAG_MODE = "mode";
 
     public ItemVoidwalkerSash () {
         super(20);
@@ -44,7 +42,7 @@ public class ItemVoidwalkerSash extends ItemRunic implements IRunicArmor, IWarpi
 
     @Override
     public void addInformation (final ItemStack stack, final EntityPlayer player, final List list, final boolean b) {
-        if (isSpeedEnabled(stack)) {
+        if (TaintedMagic.proxy.isSashEnabled(player)) {
             list.add(EnumChatFormatting.GREEN + StatCollector.translateToLocal("text.sash.speed.on"));
         }
         else {
@@ -95,33 +93,14 @@ public class ItemVoidwalkerSash extends ItemRunic implements IRunicArmor, IWarpi
 
     @Override
     public ItemStack onItemRightClick (final ItemStack stack, final World world, final EntityPlayer player) {
-        if (!world.isRemote && player.isSneaking()) {
-            if (stack.stackTagCompound == null) {
-                stack.setTagCompound(new NBTTagCompound());
-                stack.stackTagCompound.setBoolean(TAG_MODE, true);
-            }
-            if (stack.stackTagCompound != null) {
-                stack.stackTagCompound.setBoolean(TAG_MODE, !stack.stackTagCompound.getBoolean(TAG_MODE));
-                if (isSpeedEnabled(stack)) {
-                    HUDHandler.displayString(EnumChatFormatting.GREEN + StatCollector.translateToLocal("text.sash.speed.on"),
-                            300, false);
-                }
-                else {
-                    HUDHandler.displayString(EnumChatFormatting.RED + StatCollector.translateToLocal("text.sash.speed.off"),
-                            300, false);
-                }
+        if (player.isSneaking()) {
+            if (world.isRemote) {
+                SashClientHandler.toggle();
+            } else {
+                SashServerHandler.toggleSashStatus(player);
             }
         }
         return stack;
-    }
-
-    /**
-     * Returns true if the speed boost feature is enabled.
-     */
-    public static boolean isSpeedEnabled (final ItemStack stack) {
-        if (stack.stackTagCompound == null)
-            return true;
-        return stack.stackTagCompound.getBoolean(TAG_MODE);
     }
 
 }

--- a/src/main/java/taintedmagic/common/network/PacketHandler.java
+++ b/src/main/java/taintedmagic/common/network/PacketHandler.java
@@ -12,5 +12,6 @@ public class PacketHandler {
 
     public static void initPackets () {
         INSTANCE.registerMessage(PacketKatanaAttack.class, PacketKatanaAttack.class, 0, Side.SERVER);
+        INSTANCE.registerMessage(PacketSashToggle.class, PacketSashToggle.class, 1, Side.SERVER);
     }
 }

--- a/src/main/java/taintedmagic/common/network/PacketSashToggle.java
+++ b/src/main/java/taintedmagic/common/network/PacketSashToggle.java
@@ -1,0 +1,36 @@
+package taintedmagic.common.network;
+
+import baubles.common.lib.PlayerHandler;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import taintedmagic.client.handler.SashServerHandler;
+import taintedmagic.common.items.equipment.ItemVoidwalkerSash;
+
+public class PacketSashToggle implements IMessage, IMessageHandler<PacketSashToggle, IMessage> {
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        // do nothing
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        // do nothing
+    }
+
+    @Override
+    public IMessage onMessage(PacketSashToggle message, MessageContext ctx) {
+        EntityPlayer player = ctx.getServerHandler().playerEntity;
+
+        final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
+        if (sash != null && sash.getItem() instanceof ItemVoidwalkerSash) {
+            SashServerHandler.toggleSashStatus(player);
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/assets/taintedmagic/lang/en_US.lang
+++ b/src/main/resources/assets/taintedmagic/lang/en_US.lang
@@ -1,6 +1,8 @@
 #Tainted Magic English (US) localization
 
 itemGroup.TaintedMagic=Tainted Magic
+tmisc.keyCategory=Tainted Magic
+tmisc.toggleSash=Toggle Voidwalker's Sash of Runic Shielding
 
 text.creation=The voices become silent... you suddenly experience complete clarity.
 

--- a/src/main/resources/assets/taintedmagic/lang/ru_RU.lang
+++ b/src/main/resources/assets/taintedmagic/lang/ru_RU.lang
@@ -1,6 +1,8 @@
 #Tainted Magic Russian (RU) localization by Pinger
 
-itemGroup.TaintedMagic=Мракобесие
+itemGroup.TaintedMagic=Tainted Magic
+tmisc.keyCategory=Tainted Magic
+tmisc.toggleSash=Переключить эффект рунного пояса Странника Бездны
 
 text.creation=Голоса стихают... Вы чувствуете, как ваше сознание проясняется.
 


### PR DESCRIPTION
Running around your base at high speed can sometimes be annoying, even more annoying is when you have to open your baubles to toggle sash by right clicking it.