### PR TITLE
Fix Clearing Mages's Mace Equipped Flag

### DIFF
--- a/src/main/java/taintedmagic/common/handler/TaintedMagicEventHandler.java
+++ b/src/main/java/taintedmagic/common/handler/TaintedMagicEventHandler.java
@@ -109,7 +109,7 @@ public class TaintedMagicEventHandler {
         }
 
         NBTTagCompound tagMageMace = stack.stackTagCompound.getCompoundTag("MageMace");
-        tagMageMace.setBoolean("isMageMaceActive", true);
+        tagMageMace.setBoolean("isMageMaceActive", isActive);
         tagMageMace.setInteger("countOfPotency", potency);
 
         // AttributeModifier and damage


### PR DESCRIPTION
Mage's Mace focus damage is done on a tick update, so it sets a flag when the focus is equipped so that damage is only added once.

This was hard-coded to true which led to removing the focus causing the wand or staff to never be able to use the focus again.

This PR rewrites the hard-coded true to take the isActive function argument that was just going unused.

Tested in nightly 563 with no issues.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16597