### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/taintedmagic/lang/en_US.lang
+++ b/src/main/resources/assets/taintedmagic/lang/en_US.lang
@@ -44,6 +44,7 @@ tile.BlockWarpwoodPlanks.name=Warpwood Planks
 
 #=========ITEM NAMES===================
 
+item.ItemMaterial.name=Resource
 item.ItemMaterial.0.name=Shadowmetal Ingot
 item.ItemMaterial.1.name=Shadow-Imbued Cloth
 item.ItemMaterial.2.name=Crimson-Stained Cloth
@@ -73,6 +74,7 @@ item.ItemVoidwalkerBoots.name=Boots of the Voidwalker
 item.ItemWarpedGoggles.name=Warped Goggles of Revealing
 item.ItemVoidmetalGoggles.name=Voidmetal Goggles of Revealing
 
+item.ItemKatana.name=Fortress Blade
 item.ItemKatana.0.name=Thaumium Fortress Blade
 item.ItemKatana.1.name=Voidmetal Fortress Blade
 item.ItemKatana.2.name=Shadowmetal Fortress Blade
@@ -115,9 +117,11 @@ item.ItemFocusMeteorology.name=Wand Focus: Meteorology
 item.ItemFocusTime.name=Wand Focus: Time
 item.ItemFocusVisShard.name=Wand Focus: Vis Shard
 
+item.ItemWandRod.name=Warpwood Rod/Staff Core
 item.ItemWandRod.0.name=Warpwood Rod
 item.ItemWandRod.1.name=Warpwood Staff Core
 
+item.ItemWandCap.name=Cap
 item.ItemWandCap.0.name=Shadowmetal Cap
 item.ItemWandCap.1.name=Enchanted Cloth Cap
 item.ItemWandCap.2.name=Crimson-Stained Cloth Cap


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.