### PR TITLE
Fix Voidwalker Vis Discount TT

### DIFF
--- a/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerBoots.java
+++ b/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerBoots.java
@@ -9,6 +9,8 @@ import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor;
 import net.minecraftforge.common.MinecraftForge;
@@ -92,8 +94,14 @@ public class ItemVoidwalkerBoots extends ItemArmor
         if (source != DamageSource.fall) s.damageItem(dmg, e);
     }
 
-    @Override
-    public void addInformation(ItemStack s, EntityPlayer p, List l, boolean b) {}
+    public void addInformation(ItemStack s, EntityPlayer p, List l, boolean b) {
+        l.add(
+                EnumChatFormatting.DARK_PURPLE + StatCollector.translateToLocal("tc.visdiscount")
+                        + ": "
+                        + getVisDiscount(s, p, null)
+                        + "%");
+        super.addInformation(s, p, l, b);
+    }
 
     public void onUpdate(ItemStack s, World w, Entity e, int j, boolean k) {
         super.onUpdate(s, w, e, j, k);


### PR DESCRIPTION
adds the missing Vis Discount to the Voidwalker Boots Tooltip, like every other Armor Piece
Before:
![image](https://github.com/user-attachments/assets/3a4aaae2-4279-4271-aa9c-bdfb5763af6c)
After:
![image](https://github.com/user-attachments/assets/9b4a337d-2f3d-4e4d-aa52-eb0bc8565cdb)
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16571 (even tho its already closed as not planned)