### PR TITLE
Fix Boots of the Voidwalker

### DIFF
--- a/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerBoots.java
+++ b/src/main/java/taintedmagic/common/items/equipment/ItemVoidwalkerBoots.java
@@ -177,14 +177,14 @@ public class ItemVoidwalkerBoots extends ItemArmor
 
     // Avoid NSM Exception when ThaumicBoots is not present.
     public double getSpeedModifier(ItemStack stack) {
-        if (stack.stackTagCompound != null) {
+        if (stack.stackTagCompound != null && stack.stackTagCompound.hasKey("speed")) {
             return stack.stackTagCompound.getDouble("speed");
         }
         return 1.0;
     }
 
     public double getJumpModifier(ItemStack stack) {
-        if (stack.stackTagCompound != null) {
+        if (stack.stackTagCompound != null && stack.stackTagCompound.hasKey("jump")) {
             return stack.stackTagCompound.getDouble("jump");
         }
         return 1.0;


### PR DESCRIPTION
The Boots of the Voidwalker work perfectly fine when unenchanted, but once you enchant them, the speed & jump boost no longer work (disenchanting also doesn't fix it). Adding hasKey() checks fixes this issue.